### PR TITLE
remove check that s3_object exists as is causing error when downloading

### DIFF
--- a/app/controllers/hyrax/downloads_controller.rb
+++ b/app/controllers/hyrax/downloads_controller.rb
@@ -47,17 +47,17 @@ module Hyrax
                       else
                         Aws::S3::Object.new(ENV['AWS_BUCKET'], file.digest.first.to_s.gsub('urn:sha1:', ''))
                       end
-          if s3_object.exists?
-            STDERR.puts "##################################"
-            STDERR.puts "Redirecting to S3 using the filename #{file.original_name}"
-            STDERR.puts "File object: #{file}"
-            redirect_to s3_object.presigned_url(
-              :get,
-              expires_in: 3600,
-              response_content_disposition: "attachment\; filename=#{file.original_name}"
-            )
-            return
-          end
+          #if s3_object.exists? #Disabling until such time that the bucket allows the correct resource to s3:ListObject
+          #STDERR.puts "##################################"
+          #STDERR.puts "Redirecting to S3 using the filename #{file.original_name}"
+          #STDERR.puts "File object: #{file}"
+          redirect_to s3_object.presigned_url(
+            :get,
+            expires_in: 3600,
+            response_content_disposition: "attachment\; filename=#{file.original_name}"
+          )
+          return
+          #end
         end
         # from here on this is effectively `super` if this was a decorator
         # will fall back to streaming object via fedora


### PR DESCRIPTION
# Story

Downloads (which come direct from s3) are failing due to a 403. Some testing revealed that the operation being refused is Aws::S3::Object#exists? and this requires permission to s3:ListObject. Have removed the condition until we can amend bucket policies.

# Expected Behaviour Before Changes

downloads throw error

# Expected Behaviour After Changes

Downloads download

